### PR TITLE
Delete redundant content

### DIFF
--- a/articles/iot-edge/how-to-deploy-monitor.md
+++ b/articles/iot-edge/how-to-deploy-monitor.md
@@ -70,8 +70,7 @@ ms.lasthandoff: 12/07/2017
 1. 选择“添加自定义 IoT Edge 模块”。
 1. 为模块提供一个名称。
 1. 对于映像字段，输入此模块的 Docker 容器映像：`microsoft/azureiotedge-simulated-temperature-sensor:1.0-preview`。
-1. 使用“OS”和“构架”下的下拉菜单来标识代表此模块的 Docker 容器的属性。 
-1. 指定应传递到容器的任意 Create 选项。 有关详细信息，请参阅 [docker create][lnk-docker-create]。
+1. 指定应传递到容器的任意 Create 选项。 有关详细信息，请参阅 [docker create][lnk-docker-create]。 
 1. 使用下拉菜单选择“重启策略”。 从以下选项中选择： 
    * 始终 - 如果模块因任何原因关闭，该模块将始终重启。
    * 从不 - 如果模块因任何原因关闭，该模块将不再重启。


### PR DESCRIPTION
According to the original English content (https://docs.microsoft.com/en-us/azure/iot-edge/how-to-deploy-monitor), "使用“OS”和“构架”下的下拉菜单来标识代表此模块的 Docker 容器的属性" should not appear here.