### PR TITLE
使用令牌部分增加了Custom Voice的细节说明

### DIFF
--- a/articles/cognitive-services/Speech-Service/rest-apis.md
+++ b/articles/cognitive-services/Speech-Service/rest-apis.md
@@ -174,6 +174,10 @@ Connection: Keep-Alive
     Hello, world!
 </voice></speak>
 ```
+> [!NOTE]
+> Custom Voice服务中 ``` <voice> ``` 中 ``` name ``` 属性应为Font Name，否则将会报错。
+  
+  ![FontName](https://raw.githubusercontent.com/SylvesterLi/NoteRepo/master/PicSource/FontName.png)
 
 ### <a name="renewing-authorization"></a>续订授权
 


### PR DESCRIPTION
文档整体是对的，只是少了一些错误说明。在实际使用中发现Voice name属性如果与Font Name不符，会报错400。