### PR TITLE
Missing a step

### DIFF
--- a/articles/azure-resource-manager/management/move-limitations/virtual-machines-move-limitations.md
+++ b/articles/azure-resource-manager/management/move-limitations/virtual-machines-move-limitations.md
@@ -30,6 +30,7 @@ ms.locfileid: "75479756"
 若要移动使用 Azure 备份配置的虚拟机，请使用以下解决方法：
 
 * 找到虚拟机的位置。
+* 解除分配虚拟机。
 * 找到含有以下命名模式的资源组：`AzureBackupRG_<location of your VM>_1` 例如，AzureBackupRG_westus2_1
 * 如果在 Azure 门户中，则查看“显示隐藏的类型”
 * 如果在 PowerShell 中，则使用 `Get-AzResource -ResourceGroupName AzureBackupRG_<location of your VM>_1` cmdlet


### PR DESCRIPTION
删除即时恢复点前需要先解除分配虚拟机。You need to unallocate the virtual machine before deleting the instant recovery points

建议的有用信息：
1.请参阅[快速入门本地化样式指南](https://docs.microsoft.com/globalization/localization/styleguides)，了解 Microsoft 风格指南中**最重要的十大规则**。
2.请参阅 [Microsoft 语言门户](https://www.microsoft.com/language)，查看各 Microsoft 产品的**标准化术语翻译**。
